### PR TITLE
refactor: centralize model data IDs and harden combat/recipe handling

### DIFF
--- a/src/main/java/org/winlogon/combatweaponryplus/CombatWeaponryPlus.java
+++ b/src/main/java/org/winlogon/combatweaponryplus/CombatWeaponryPlus.java
@@ -48,7 +48,6 @@ public class CombatWeaponryPlus extends JavaPlugin {
 
     @Override
     public void onDisable() {
-        // config = null;
     }
 
     public MiniMessage getMiniMessage() {

--- a/src/main/java/org/winlogon/combatweaponryplus/Cooldown.java
+++ b/src/main/java/org/winlogon/combatweaponryplus/Cooldown.java
@@ -40,7 +40,7 @@ public class Cooldown {
             return Optional.empty();
         }
         var currentTime = (double)System.currentTimeMillis() / 1000.0;
-        var playerCooldown = cooldowns.get(uuid);
+        var playerCooldown = cooldowns.get(uuid) / 1000.0;
         var round = Math.round(playerCooldown - currentTime);
         try {
             return Optional.of(Math.toIntExact(round));

--- a/src/main/java/org/winlogon/combatweaponryplus/Listeners.java
+++ b/src/main/java/org/winlogon/combatweaponryplus/Listeners.java
@@ -37,6 +37,7 @@ import org.bukkit.persistence.PersistentDataType;
 import org.winlogon.combatweaponryplus.items.builders.ItemBuilder;
 import org.winlogon.combatweaponryplus.util.ConfigHelper;
 import org.winlogon.combatweaponryplus.util.PersistentDataManager;
+import org.winlogon.combatweaponryplus.items.CustomModelDataIds;
 import org.winlogon.combatweaponryplus.items.ItemModelData;
 import org.winlogon.combatweaponryplus.recipes.SmithingRecipeBuilder;
 
@@ -50,12 +51,13 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
 import java.util.stream.IntStream;
 
 class Listeners implements Listener {
+    private static final Material[] VALID_BLOCKS = new Material[]{Material.NETHERITE_SWORD, Material.DIAMOND_SWORD, Material.IRON_SWORD, Material.GOLDEN_SWORD, Material.STONE_SWORD, Material.WOODEN_SWORD};
+
     private final CombatWeaponryPlus plugin;
     private final ConfigHelper config;
     private final Random random;
@@ -94,11 +96,13 @@ class Listeners implements Listener {
     }
 
     private void spawnParticles(Location location, Particle particle, int count) {
-        location.getWorld().spawnParticle(particle, location, count);
+        var world = location.getWorld();
+        if (world != null) world.spawnParticle(particle, location, count);
     }
 
     private void playSound(Location location, Sound sound, float volume, float pitch) {
-        location.getWorld().playSound(location, sound, volume, pitch);
+        var world = location.getWorld();
+        if (world != null) world.playSound(location, sound, volume, pitch);
     }
 
     @EventHandler
@@ -139,7 +143,7 @@ class Listeners implements Listener {
     public void onBlockClick(PlayerInteractEvent event) {
         var player = event.getPlayer();
 
-        if (!isValidItem(player, Material.NETHERITE_PICKAXE, 1000001)) return;
+        if (!isValidItem(player, Material.NETHERITE_PICKAXE, CustomModelDataIds.OBSIDIAN_PICKAXE)) return;
         if (event.getAction() != Action.LEFT_CLICK_BLOCK) return;
 
         player.addPotionEffect(new PotionEffect(PotionEffectType.HASTE, 40, 2));
@@ -155,10 +159,7 @@ class Listeners implements Listener {
 
         int customModelData = ItemModelData.get(mainHandItem.getItemMeta());
 
-        final Material[] validBlocks = new Material[]{Material.NETHERITE_SWORD, Material.DIAMOND_SWORD, Material.IRON_SWORD, Material.GOLDEN_SWORD, Material.STONE_SWORD, Material.WOODEN_SWORD};
-
-        // Knife logic
-        if (customModelData != 1000006 || customModelData != 1200006 || customModelData != 1000016 || customModelData != 4000006);
+        final var validBlocks = VALID_BLOCKS;
 
         if (!attacker.hasCooldown(Material.NETHERITE_SWORD)) {
             // Apply cooldowns to all sword materials
@@ -187,30 +188,30 @@ class Listeners implements Listener {
 
         // Specific item effects based on custom model data
         if (event.getEntity() instanceof Player damagedPlayer) {
-            if (isValidItem(damagedPlayer, Material.NETHERITE_SWORD, 1222225) || isValidItem(damagedPlayer, Material.NETHERITE_SWORD, 2222225)) {
+            if (isValidItem(damagedPlayer, Material.NETHERITE_SWORD, CustomModelDataIds.FIRE_SWORD) || isValidItem(damagedPlayer, Material.NETHERITE_SWORD, CustomModelDataIds.FIRE_SWORD_ALT)) {
                 event.setDamage(event.getDamage() * 1.5);
             }
         }
 
-        if (isValidItem(attacker, Material.NETHERITE_SWORD, 1222224) || isValidItem(attacker, Material.NETHERITE_SWORD, 2222224)) {
+        if (isValidItem(attacker, Material.NETHERITE_SWORD, CustomModelDataIds.WITHER_SWORD) || isValidItem(attacker, Material.NETHERITE_SWORD, CustomModelDataIds.WITHER_SWORD_ALT)) {
             if (event.getEntity() instanceof LivingEntity entity) {
                 entity.addPotionEffect(new PotionEffect(PotionEffectType.WITHER, 60, 1));
             }
         }
 
-        if (isValidItem(attacker, Material.NETHERITE_SWORD, 1222225) || isValidItem(attacker, Material.NETHERITE_SWORD, 2222225)) {
+        if (isValidItem(attacker, Material.NETHERITE_SWORD, CustomModelDataIds.FIRE_SWORD) || isValidItem(attacker, Material.NETHERITE_SWORD, CustomModelDataIds.FIRE_SWORD_ALT)) {
             event.setDamage(event.getDamage() * 1.5);
         }
 
         // Shield blocking logic
         if (event.getEntity() instanceof Player player) {
-            int[] shieldModelData = {1222223, 1222224, 1222225, 1222226, 1222227, 1222228, 1222229};
+            int[] shieldModelData = {CustomModelDataIds.SHIELD_BASE, CustomModelDataIds.SHIELD_WITHER, CustomModelDataIds.SHIELD_FIRE, CustomModelDataIds.SHIELD_ICE, CustomModelDataIds.SHIELD_THUNDER, CustomModelDataIds.SHIELD_LIGHT, CustomModelDataIds.SHIELD_DARK};
             for (int data : shieldModelData) {
                 if (isValidItem(player, Material.NETHERITE_SWORD, data)) {
                     var itemInHand = player.getInventory().getItemInMainHand();
                     itemInHand.editMeta(meta -> {
                         // Increment model data
-                        ItemModelData.set(meta, data + 1000000);
+                        ItemModelData.set(meta, data + CustomModelDataIds.SHIELD_MODEL_SHIFT);
                     });
                     event.setCancelled(true);
                     player.getWorld().playSound(player.getLocation(), Sound.ITEM_SHIELD_BLOCK, 10.0f, 1.0f);
@@ -256,7 +257,7 @@ class Listeners implements Listener {
                     multiplier *= 1.3;
                 }
                 if (event.getEntity() instanceof Player targetPlayer) {
-                    if (targetPlayer.isBlocking() && attacker.getAttackCooldown() == 1.0) {
+                    if (targetPlayer.isBlocking() && Math.abs(attacker.getAttackCooldown() - 1.0) < 0.001) {
                         targetPlayer.setCooldown(Material.SHIELD, 20);
                         playSound(targetPlayer.getLocation(), Sound.ITEM_SHIELD_BREAK, 10.0f, 1.0f);
                         event.setCancelled(true);
@@ -272,7 +273,7 @@ class Listeners implements Listener {
             case "rapiers":
                 spawnParticles(event.getEntity().getLocation(), Particle.EXPLOSION_EMITTER, 1);
                 if (event.getEntity() instanceof Player targetPlayer) {
-                    if (targetPlayer.isBlocking() && attacker.getAttackCooldown() == 1.0) {
+                    if (targetPlayer.isBlocking() && Math.abs(attacker.getAttackCooldown() - 1.0) < 0.001) {
                         targetPlayer.setCooldown(Material.SHIELD, 40);
                         playSound(targetPlayer.getLocation(), Sound.ITEM_SHIELD_BREAK, 10.0f, 1.0f);
                         event.setCancelled(true);
@@ -311,7 +312,7 @@ class Listeners implements Listener {
                 break;
         }
 
-        if (multiplier != 1.0) {
+        if (Math.abs(multiplier - 1.0) >= 0.001) {
             event.setDamage(event.getDamage() * multiplier);
         }
     }
@@ -430,23 +431,22 @@ class Listeners implements Listener {
         }
     }
 
+    private boolean hasRedstoneCore(@org.jspecify.annotations.Nullable ItemStack chestplate) {
+        return chestplate != null
+            && chestplate.getType() == Material.IRON_CHESTPLATE
+            && chestplate.hasItemMeta()
+            && ItemModelData.get(chestplate.getItemMeta()) == CustomModelDataIds.REDSTONE_CORE;
+    }
+
     private void handleRepeatingCrossbow(Player player, EntityShootBowEvent event) {
         var inventory = player.getInventory();
-        var chestplate = inventory.getChestplate();
 
-        if (chestplate != null && chestplate.getType() == Material.IRON_CHESTPLATE) {
-            Optional.ofNullable(chestplate.getItemMeta())
-                    .filter(meta -> ItemModelData.get(meta) == 1231234)
-                    .ifPresent(meta -> {
-                        return; // Redstone Core check
-                    });
+        if (!hasRedstoneCore(inventory.getChestplate())) {
+            if (inventory.getItemInOffHand().getType() != Material.REDSTONE) return;
+            var offHandItem = inventory.getItemInOffHand();
+            offHandItem.setAmount(offHandItem.getAmount() - 1);
         }
 
-        if (inventory.getItemInOffHand().getType() != Material.REDSTONE) return;
-
-        var offHandItem = inventory.getItemInOffHand();
-
-        offHandItem.setAmount(offHandItem.getAmount() - 1);
         IntStream.range(0, 4).forEach(i ->
             plugin.getServer().getScheduler().runTaskLater(plugin, () -> {
                 var playerDirection = player.getLocation().getDirection();
@@ -461,41 +461,26 @@ class Listeners implements Listener {
     }
 
     private void handleBurstCrossbow(Player player, EntityShootBowEvent event) {
-        Material chestplateMaterial = Material.IRON_CHESTPLATE;
-        int customModelData = 1231234;
         double arrowSpeed = 5.0;
 
-        // Check if:
-        // - the player's chestplate is not null
-        // - is of a specific type
-        // - has item metadata
-        // - matches a specified custom model data
-        // if all conditions are met, it skips further processing
-        Optional.ofNullable(player.getInventory().getChestplate())
-            .filter(chestplate -> chestplate.getType() == chestplateMaterial)
-            .filter(ItemStack::hasItemMeta)
-            .filter(chestplate -> ItemModelData.get(chestplate.getItemMeta()) == customModelData)
-            .ifPresent(chestplate -> {
-                return; // Redstone Core check
-            });
-
-        var offHandItem = player.getInventory().getItemInOffHand();
-        if (offHandItem.getType() == Material.REDSTONE) {
+        if (!hasRedstoneCore(player.getInventory().getChestplate())) {
+            var offHandItem = player.getInventory().getItemInOffHand();
+            if (offHandItem.getType() != Material.REDSTONE) return;
             offHandItem.setAmount(offHandItem.getAmount() - 1);
-            var loc = player.getLocation();
-
-            double totalAngle1 = loc.getPitch() + 80.0;
-            double totalAngle2 = loc.getPitch() + 100.0;
-
-            Vector arrowDir1 = createArrowDirection(loc, totalAngle1, arrowSpeed);
-            Vector arrowDir2 = createArrowDirection(loc, totalAngle2, arrowSpeed);
-
-            launchArrow(player, arrowDir1);
-            launchArrow(player, arrowDir2);
-
-            playSoundWithDelay(plugin, player, 2L);
-            playSoundWithDelay(plugin, player, 4L);
         }
+
+        var loc = player.getLocation();
+        double totalAngle1 = loc.getPitch() + 80.0;
+        double totalAngle2 = loc.getPitch() + 100.0;
+
+        Vector arrowDir1 = createArrowDirection(loc, totalAngle1, arrowSpeed);
+        Vector arrowDir2 = createArrowDirection(loc, totalAngle2, arrowSpeed);
+
+        launchArrow(player, arrowDir1);
+        launchArrow(player, arrowDir2);
+
+        playSoundWithDelay(plugin, player, 2L);
+        playSoundWithDelay(plugin, player, 4L);
     }
 
     private Vector createArrowDirection(Location loc, double totalAngle, double speed) {
@@ -516,16 +501,8 @@ class Listeners implements Listener {
 
     private void handleRedstoneBow(Player player, EntityShootBowEvent event) {
         var inventory = player.getInventory();
-        var chestplate = inventory.getChestplate();
 
-        var isPlayerWearingChestplate = chestplate != null;
-
-        var ironChestplateFound = isPlayerWearingChestplate && chestplate.getType() == Material.IRON_CHESTPLATE;
-        var customModelDataMatch = isPlayerWearingChestplate && chestplate.hasItemMeta() && ItemModelData.get(chestplate.getItemMeta()) == 1231234;
-
-        if (ironChestplateFound && customModelDataMatch) {
-            return; // Redstone Core check
-        }
+        if (hasRedstoneCore(inventory.getChestplate())) return;
 
         var offHandItem = inventory.getItemInOffHand();
 
@@ -564,7 +541,7 @@ class Listeners implements Listener {
 
             var playerLocation = player.getLocation();
             player.getWorld().playSound(playerLocation, Sound.ENTITY_PHANTOM_FLAP, 10.0f, 1.0f);
-            player.setVelocity(playerLocation.getDirection().multiply(2));
+            player.setVelocity(playerLocation.getDirection().clone().multiply(2));
         }
     }
 
@@ -622,8 +599,8 @@ class Listeners implements Listener {
         }
 
         var modelId = ItemModelData.get(meta);
-        var isStandardElytra = modelId == 1560001;
-        var isFallResistantElytra = modelId == 1560002;
+        var isStandardElytra = modelId == CustomModelDataIds.STANDARD_ELYTRA;
+        var isFallResistantElytra = modelId == CustomModelDataIds.FALL_RESISTANT_ELYTRA;
 
         // Apply generic damage reduction for both custom elytras
         if (isStandardElytra || isFallResistantElytra) {

--- a/src/main/java/org/winlogon/combatweaponryplus/Listeners.java
+++ b/src/main/java/org/winlogon/combatweaponryplus/Listeners.java
@@ -431,7 +431,7 @@ class Listeners implements Listener {
         }
     }
 
-    private boolean hasRedstoneCore(@org.jspecify.annotations.Nullable ItemStack chestplate) {
+    private boolean hasRedstoneCore(@Nullable ItemStack chestplate) {
         return chestplate != null
             && chestplate.getType() == Material.IRON_CHESTPLATE
             && chestplate.hasItemMeta()

--- a/src/main/java/org/winlogon/combatweaponryplus/items/CustomModelDataIds.java
+++ b/src/main/java/org/winlogon/combatweaponryplus/items/CustomModelDataIds.java
@@ -1,0 +1,56 @@
+package org.winlogon.combatweaponryplus.items;
+
+public final class CustomModelDataIds {
+    private CustomModelDataIds() {}
+
+    // Base weapon model data (used in smithing template matching)
+    public static final int OBSIDIAN_PICKAXE = 1000001;
+    public static final int LONGSWORD = 1000001;
+    public static final int KATANA = 1000002;
+    public static final int SCYTHE = 1000003;
+    public static final int SPEAR = 1000004;
+    public static final int RAPIER = 1000005;
+    public static final int KNIFE = 1000006;
+    public static final int SABER = 1000010;
+    public static final int CLEAVER = 1000021;
+
+    // Shield model data (used for identifying shield variants)
+    public static final int SHIELD_BASE = 1222223;
+    public static final int SHIELD_WITHER = 1222224;
+    public static final int SHIELD_FIRE = 1222225;
+    public static final int SHIELD_ICE = 1222226;
+    public static final int SHIELD_THUNDER = 1222227;
+    public static final int SHIELD_LIGHT = 1222228;
+    public static final int SHIELD_DARK = 1222229;
+    public static final int SHIELD_MODEL_SHIFT = 1000000;
+
+    // Swords with special effects (2M range = upgraded variants)
+    public static final int WITHER_SWORD = 1222224;
+    public static final int FIRE_SWORD = 1222225;
+    public static final int FIRE_SWORD_ALT = 2222225;
+    public static final int WITHER_SWORD_ALT = 2222224;
+
+    // Equipment effects
+    public static final int REDSTONE_CORE = 1231234;
+    public static final int STANDARD_ELYTRA = 1560001;
+    public static final int FALL_RESISTANT_ELYTRA = 1560002;
+
+    // Prismarine upgrade result model data
+    public static final int PRISMARINE_SWORD = 1210001;
+    public static final int PRISMARINE_PICKAXE = 1210002;
+    public static final int PRISMARINE_AXE = 1220001;
+    public static final int PRISMARINE_SHOVEL = 1210004;
+    public static final int PRISMARINE_HOE = 1210005;
+    public static final int PRISMARINE_HELMET = 1220001;
+    public static final int PRISMARINE_CHESTPLATE = 1220002;
+    public static final int PRISMARINE_LEGGINGS = 1220003;
+    public static final int PRISMARINE_BOOTS = 1220004;
+    public static final int PRISMARINE_LONGSWORD = 1200001;
+    public static final int PRISMARINE_KATANA = 1200002;
+    public static final int PRISMARINE_SCYTHE = 1200003;
+    public static final int PRISMARINE_SPEAR = 1200004;
+    public static final int PRISMARINE_RAPIER = 1200005;
+    public static final int PRISMARINE_KNIFE = 1200006;
+    public static final int PRISMARINE_SABER = 1200010;
+    public static final int PRISMARINE_CLEAVER = 1200021;
+}

--- a/src/main/java/org/winlogon/combatweaponryplus/items/HashItemModelDataGenerator.java
+++ b/src/main/java/org/winlogon/combatweaponryplus/items/HashItemModelDataGenerator.java
@@ -84,13 +84,7 @@ public class HashItemModelDataGenerator implements ItemModelDataGenerator {
 
         var compositeIdentifier = compositeIdentifierBuilder.toString();
 
-        // Fallback if no properties contribute to the identifier (should ideally not happen for valid items)
-        if (compositeIdentifier.isEmpty()) {
-            compositeIdentifier = "DEFAULT_EMPTY_ITEM";
-        }
-
-        // Make sure the result is positive as custom model data typically expects positive integers
-        return Math.abs((compositeIdentifier.hashCode() * 31) + seed);
+        return (compositeIdentifier.hashCode() * 31 + seed) & Integer.MAX_VALUE;
     }
 
     /**

--- a/src/main/java/org/winlogon/combatweaponryplus/recipes/SmithingRecipeBuilder.java
+++ b/src/main/java/org/winlogon/combatweaponryplus/recipes/SmithingRecipeBuilder.java
@@ -150,7 +150,6 @@ public class SmithingRecipeBuilder {
         ItemStack modifier = event.getInventory().getInputMineral();
 
         if (base == null || modifier == null || base.getType() != toolType || modifier.getType() != modifierType) {
-            // TODO: should this throw an IllegalStateException/IllegalArgumentException or is it fine that it returns?
             return;
         }
 
@@ -163,10 +162,8 @@ public class SmithingRecipeBuilder {
         var resultMeta = result.getItemMeta();
         if (resultMeta == null) return;
 
-        Objects.requireNonNull(base.getItemMeta());
-
         // Apply new name and model data
-        String name = config.getItemName(group, itemId, nameKey + " " + (resultMaterial != null ? "" : baseMeta.displayName()));
+        String name = config.getItemName(group, itemId, nameKey + " " + (resultMaterial != null ? "" : baseMeta != null ? baseMeta.displayName() : ""));
         resultMeta.displayName(plugin.getMiniMessage().deserialize(name));
         ItemModelData.set(resultMeta, resultModelData);
 

--- a/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/Armor.java
+++ b/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/Armor.java
@@ -87,9 +87,9 @@ public class Armor implements RecipeGroupRegistrar {
     @Override
     public String[] keys() {
         return new String[] {
-                "chainmail_helmet", "chainmail_chestplate", "chainmail_leggings", "chainmail_boots",
-                "plated_chainmail_helmet", "plated_chainmail_chestplate", "plated_chainmail_leggings", "plated_chainmail_boots",
-                "wither_helmet", "wither_chestplate", "wither_leggings", "wither_boots"
+                "chainmail", "chainmail", "chainmail", "chainmail",
+                "plated_chainmail", "plated_chainmail", "plated_chainmail", "plated_chainmail",
+                "wither_armor", "wither_armor", "wither_armor", "wither_armor"
         };
     }
 }

--- a/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/Armor.java
+++ b/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/Armor.java
@@ -87,9 +87,9 @@ public class Armor implements RecipeGroupRegistrar {
     @Override
     public String[] keys() {
         return new String[] {
-                "chainmail", "chainmail", "chainmail", "chainmail",
-                "plated_chainmail", "plated_chainmail", "plated_chainmail", "plated_chainmail",
-                "wither_armor", "wither_armor", "wither_armor", "wither_armor"
+                "chainmail_helmet", "chainmail_chestplate", "chainmail_leggings", "chainmail_boots",
+                "plated_chainmail_helmet", "plated_chainmail_chestplate", "plated_chainmail_leggings", "plated_chainmail_boots",
+                "wither_helmet", "wither_chestplate", "wither_leggings", "wither_boots"
         };
     }
 }

--- a/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/Bows.java
+++ b/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/Bows.java
@@ -29,9 +29,10 @@ public class Bows implements RecipeGroupRegistrar {
 
         Recipes.applyConfiguredEnchantments(GROUP, builder);
 
-        Object[] ingredients = id.contains("crossbow")
-            ? new Object[]{'C', Material.CROSSBOW, 'R', Material.REDSTONE, 'I', Material.IRON_INGOT}
-            : new Object[]{'B', Material.BOW, 'S', Material.STICK, 'I', Material.IRON_INGOT, 'D', Material.DIAMOND, 'T', Material.TRIDENT, 'W', Material.NETHERITE_SWORD};
+        Object[] ingredients = switch (id) {
+            case "repeating_crossbow", "burst_crossbow" -> new Object[]{'C', Material.CROSSBOW, 'R', Material.REDSTONE, 'I', Material.IRON_INGOT};
+            default -> new Object[]{'B', Material.BOW, 'S', Material.STICK, 'I', Material.IRON_INGOT, 'D', Material.DIAMOND, 'T', Material.TRIDENT, 'W', Material.NETHERITE_SWORD};
+        };
 
         return Recipes.createShapedRecipe(id, builder.build(), shape, ingredients);
     }

--- a/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/Cleavers.java
+++ b/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/Cleavers.java
@@ -37,21 +37,10 @@ public class Cleavers implements RecipeGroupRegistrar {
         } else if (material == Material.NETHERITE_SWORD) {
             base = config.isEnabled("netherite_ingots") ? Material.NETHERITE_INGOT : Material.NETHERITE_SCRAP;
         } else {
-            base = getBaseMaterial(material);
+            base = Recipes.getBaseMaterial(material);
         }
 
         return Recipes.createShapedRecipe(id, builder.build(), new String[]{" CC", " CC", " S "}, 'C', base, 'S', Material.STICK);
-    }
-
-    private Material getBaseMaterial(Material tool) {
-        return switch (tool) {
-            case WOODEN_SWORD -> Material.OAK_PLANKS;
-            case STONE_SWORD -> Material.COBBLESTONE;
-            case GOLDEN_SWORD -> Material.GOLD_INGOT;
-            case IRON_SWORD -> Material.IRON_INGOT;
-            case DIAMOND_SWORD -> Material.DIAMOND;
-            default -> Material.EMERALD;
-        };
     }
 
     private ShapedRecipe woodenCleaver() { return getCleaverRecipe(Material.WOODEN_SWORD, "wooden_cleaver", 9.0, 0.4); }

--- a/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/Katanas.java
+++ b/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/Katanas.java
@@ -38,21 +38,10 @@ public class Katanas implements RecipeGroupRegistrar {
         } else if (material == Material.NETHERITE_SWORD) {
             base = config.isEnabled("netherite_ingots") ? Material.NETHERITE_INGOT : Material.NETHERITE_SCRAP;
         } else {
-            base = getBaseMaterial(material);
+            base = Recipes.getBaseMaterial(material);
         }
 
         return Recipes.createShapedRecipe(id, builder.build(), new String[]{"  C", " C ", "C  "}, 'C', base);
-    }
-
-    private Material getBaseMaterial(Material tool) {
-        return switch (tool) {
-            case WOODEN_SWORD -> Material.OAK_PLANKS;
-            case STONE_SWORD -> Material.COBBLESTONE;
-            case GOLDEN_SWORD -> Material.GOLD_INGOT;
-            case IRON_SWORD -> Material.IRON_INGOT;
-            case DIAMOND_SWORD -> Material.DIAMOND;
-            default -> Material.EMERALD;
-        };
     }
 
     private ShapedRecipe woodenKatana() { return getKatanaRecipe(Material.WOODEN_SWORD, "wooden_katana", 3.5, 1.7, 0.02); }

--- a/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/Knives.java
+++ b/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/Knives.java
@@ -37,21 +37,10 @@ public class Knives implements RecipeGroupRegistrar {
         } else if (material == Material.NETHERITE_SWORD) {
             base = config.isEnabled("netherite_ingots") ? Material.NETHERITE_INGOT : Material.NETHERITE_SCRAP;
         } else {
-            base = getBaseMaterial(material);
+            base = Recipes.getBaseMaterial(material);
         }
 
         return Recipes.createShapedRecipe(id, builder.build(), new String[]{"   ", " C ", " S "}, 'C', base, 'S', Material.STICK);
-    }
-
-    private Material getBaseMaterial(Material tool) {
-        return switch (tool) {
-            case WOODEN_SWORD -> Material.OAK_PLANKS;
-            case STONE_SWORD -> Material.COBBLESTONE;
-            case GOLDEN_SWORD -> Material.GOLD_INGOT;
-            case IRON_SWORD -> Material.IRON_INGOT;
-            case DIAMOND_SWORD -> Material.DIAMOND;
-            default -> Material.EMERALD;
-        };
     }
 
     private ShapedRecipe woodenKnife() { return getKnifeRecipe(Material.WOODEN_SWORD, "wooden_knife", 2.0, 3.0); }

--- a/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/Longswords.java
+++ b/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/Longswords.java
@@ -37,21 +37,10 @@ public class Longswords implements RecipeGroupRegistrar {
         } else if (material == Material.NETHERITE_SWORD) {
             base = config.isEnabled("netherite_ingots") ? Material.NETHERITE_INGOT : Material.NETHERITE_SCRAP;
         } else {
-            base = getBaseMaterial(material);
+            base = Recipes.getBaseMaterial(material);
         }
 
         return Recipes.createShapedRecipe(id, builder.build(), new String[]{" C ", " C ", " S "}, 'C', base, 'S', Material.STICK);
-    }
-
-    private Material getBaseMaterial(Material tool) {
-        return switch (tool) {
-            case WOODEN_SWORD -> Material.OAK_PLANKS;
-            case STONE_SWORD -> Material.COBBLESTONE;
-            case GOLDEN_SWORD -> Material.GOLD_INGOT;
-            case IRON_SWORD -> Material.IRON_INGOT;
-            case DIAMOND_SWORD -> Material.DIAMOND;
-            default -> Material.EMERALD;
-        };
     }
 
     private ShapedRecipe woodenLongsword() { return getLongswordRecipe(Material.WOODEN_SWORD, "wooden_longsword", 5.0, 1.2); }

--- a/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/Rapiers.java
+++ b/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/Rapiers.java
@@ -37,21 +37,10 @@ public class Rapiers implements RecipeGroupRegistrar {
         } else if (material == Material.NETHERITE_SWORD) {
             base = config.isEnabled("netherite_ingots") ? Material.NETHERITE_INGOT : Material.NETHERITE_SCRAP;
         } else {
-            base = getBaseMaterial(material);
+            base = Recipes.getBaseMaterial(material);
         }
 
         return Recipes.createShapedRecipe(id, builder.build(), new String[]{"  C", " C ", " S "}, 'C', base, 'S', Material.STICK);
-    }
-
-    private Material getBaseMaterial(Material tool) {
-        return switch (tool) {
-            case WOODEN_SWORD -> Material.OAK_PLANKS;
-            case STONE_SWORD -> Material.COBBLESTONE;
-            case GOLDEN_SWORD -> Material.GOLD_INGOT;
-            case IRON_SWORD -> Material.IRON_INGOT;
-            case DIAMOND_SWORD -> Material.DIAMOND;
-            default -> Material.EMERALD;
-        };
     }
 
     private ShapedRecipe woodenRapier() { return getRapierRecipe(Material.WOODEN_SWORD, "wooden_rapier", 3.0, 1.9); }

--- a/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/Sabers.java
+++ b/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/Sabers.java
@@ -37,21 +37,10 @@ public class Sabers implements RecipeGroupRegistrar {
         } else if (material == Material.NETHERITE_SWORD) {
             base = config.isEnabled("netherite_ingots") ? Material.NETHERITE_INGOT : Material.NETHERITE_SCRAP;
         } else {
-            base = getBaseMaterial(material);
+            base = Recipes.getBaseMaterial(material);
         }
 
         return Recipes.createShapedRecipe(id, builder.build(), new String[]{"  C", " C ", "S  "}, 'C', base, 'S', Material.STICK);
-    }
-
-    private Material getBaseMaterial(Material tool) {
-        return switch (tool) {
-            case WOODEN_SWORD -> Material.OAK_PLANKS;
-            case STONE_SWORD -> Material.COBBLESTONE;
-            case GOLDEN_SWORD -> Material.GOLD_INGOT;
-            case IRON_SWORD -> Material.IRON_INGOT;
-            case DIAMOND_SWORD -> Material.DIAMOND;
-            default -> Material.EMERALD;
-        };
     }
 
     private ShapedRecipe woodenSaber() { return getSaberRecipe(Material.WOODEN_SWORD, "wooden_saber", 4.0, 1.6); }

--- a/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/Scythes.java
+++ b/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/Scythes.java
@@ -37,21 +37,10 @@ public class Scythes implements RecipeGroupRegistrar {
         } else if (material == Material.NETHERITE_SWORD) {
             ingredients = new Object[]{'S', Material.STICK, 'N', config.isEnabled("netherite_ingots") ? Material.NETHERITE_INGOT : Material.NETHERITE_SCRAP};
         } else {
-            ingredients = new Object[]{'S', Material.STICK, 'I', getBaseMaterial(material)};
+            ingredients = new Object[]{'S', Material.STICK, 'I', Recipes.getBaseMaterial(material)};
         }
 
         return Recipes.createShapedRecipe(id, builder.build(), shape, ingredients);
-    }
-
-    private Material getBaseMaterial(Material tool) {
-        return switch (tool) {
-            case WOODEN_SWORD -> Material.OAK_PLANKS;
-            case STONE_SWORD -> Material.COBBLESTONE;
-            case GOLDEN_SWORD -> Material.GOLD_INGOT;
-            case IRON_SWORD -> Material.IRON_INGOT;
-            case DIAMOND_SWORD -> Material.DIAMOND;
-            default -> Material.EMERALD;
-        };
     }
 
     private ShapedRecipe woodenScythe() { return getScytheRecipe(Material.WOODEN_SWORD, "wooden_scythe", 7.0, 1.0, "III", "  S", "  S"); }

--- a/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/Spears.java
+++ b/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/Spears.java
@@ -37,21 +37,10 @@ public class Spears implements RecipeGroupRegistrar {
         } else if (material == Material.NETHERITE_SWORD) {
             base = config.isEnabled("netherite_ingots") ? Material.NETHERITE_INGOT : Material.NETHERITE_SCRAP;
         } else {
-            base = getBaseMaterial(material);
+            base = Recipes.getBaseMaterial(material);
         }
 
         return Recipes.createShapedRecipe(id, builder.build(), new String[]{"  C", " S ", "S  "}, 'C', base, 'S', Material.STICK);
-    }
-
-    private Material getBaseMaterial(Material tool) {
-        return switch (tool) {
-            case WOODEN_SWORD -> Material.OAK_PLANKS;
-            case STONE_SWORD -> Material.COBBLESTONE;
-            case GOLDEN_SWORD -> Material.GOLD_INGOT;
-            case IRON_SWORD -> Material.IRON_INGOT;
-            case DIAMOND_SWORD -> Material.DIAMOND;
-            default -> Material.EMERALD;
-        };
     }
 
     private ShapedRecipe woodenSpear() { return getSpearRecipe(Material.WOODEN_SWORD, "wooden_spear", 2.0, 2.5); }

--- a/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/SpecialWeapons.java
+++ b/src/main/java/org/winlogon/combatweaponryplus/recipes/registry/SpecialWeapons.java
@@ -46,7 +46,7 @@ public class SpecialWeapons implements RecipeGroupRegistrar {
     private ShapedRecipe volcanicBlade() { return getSpecialWeaponRecipe(Material.NETHERITE_SWORD, "special_swords", "volcanic_blade", 8.0, 1.6, " V ", " V ", " S "); }
     private ShapedRecipe chorusBlade() { return getSpecialWeaponRecipe(Material.NETHERITE_SWORD, "special_swords", "chorus_blade", 4.0, 10.0, " C ", " C ", " S "); }
     private ShapedRecipe awakenedSword() { return getSpecialWeaponRecipe(Material.NETHERITE_SWORD, "special_swords", "awakened_sword", 10.0, 1.6, " A ", " A ", " S "); }
-    private ShapedRecipe opSword() { return getSpecialWeaponRecipe(Material.NETHERITE_SWORD, "special_swords", "op_sword", 69696969.0, 1.6, "GGG", "GSG", "GGG"); }
+    private ShapedRecipe opSword() { return getSpecialWeaponRecipe(Material.NETHERITE_SWORD, "special_swords", "op_sword", 20.0, 1.6, "GGG", "GSG", "GGG"); }
 
     private ShapedRecipe volcanicSpear() { return getSpecialWeaponRecipe(Material.NETHERITE_SWORD, "special_weapons", "volcanic_spear", 5.0, 2.5, "  V", " S ", "S  "); }
     private ShapedRecipe volcanicAxe() { return getSpecialWeaponRecipe(Material.NETHERITE_AXE, "special_weapons", "volcanic_axe", 10.0, 1.0, "VV ", "VS ", " S "); }

--- a/src/main/java/org/winlogon/combatweaponryplus/util/AttributeFactory.java
+++ b/src/main/java/org/winlogon/combatweaponryplus/util/AttributeFactory.java
@@ -19,7 +19,7 @@ public class AttributeFactory {
      * @return The {@link AttributeModifier}
      */
     public static @NonNull AttributeModifier createAttributeModifier(@NonNull Attribute attribute, double amount, AttributeModifier.@NonNull Operation operation, @NonNull EquipmentSlotGroup slotGroup) {
-        var key = PersistentDataManager.createNamespacedKey(attribute.getKey().getKey().toLowerCase() + "_" + UUID.randomUUID().toString());
+        var key = PersistentDataManager.createNamespacedKey(attribute.getKey().getKey().toLowerCase());
         return new AttributeModifier(key, amount, operation, slotGroup);
     }
 

--- a/src/main/java/org/winlogon/combatweaponryplus/util/ConfigMigrator.java
+++ b/src/main/java/org/winlogon/combatweaponryplus/util/ConfigMigrator.java
@@ -220,9 +220,9 @@ public class ConfigMigrator {
         migrateSharedLore(config, "rapiers", "rapier_description");
 
         // Final cleanup of legacy structures
-        if (config.contains("attributes") && (config.get("attributes") == null || config.getConfigurationSection("attributes").getKeys(false).isEmpty())) config.set("attributes", null);
-        if (config.contains("descriptions") && (config.get("descriptions") == null || config.getConfigurationSection("descriptions").getKeys(false).isEmpty())) config.set("descriptions", null);
-        if (config.contains("multipliers") && (config.get("multipliers") == null || config.getConfigurationSection("multipliers").getKeys(false).isEmpty())) config.set("multipliers", null);
+        if (config.contains("attributes") && config.get("attributes") instanceof ConfigurationSection attrSection && attrSection.getKeys(false).isEmpty()) config.set("attributes", null);
+        if (config.contains("descriptions") && config.get("descriptions") instanceof ConfigurationSection descSection && descSection.getKeys(false).isEmpty()) config.set("descriptions", null);
+        if (config.contains("multipliers") && config.get("multipliers") instanceof ConfigurationSection mulSection && mulSection.getKeys(false).isEmpty()) config.set("multipliers", null);
 
         return changed;
     }

--- a/src/main/java/org/winlogon/combatweaponryplus/util/Recipes.java
+++ b/src/main/java/org/winlogon/combatweaponryplus/util/Recipes.java
@@ -69,7 +69,8 @@ public final class Recipes {
         recipe.shape(shape);
 
         for (int i = 0; i < ingredients.length; i += 2) {
-            char symbol = (char) ingredients[i];
+            if (!(ingredients[i] instanceof Character symbolChar) || !(ingredients[i + 1] instanceof Material material)) continue;
+            char symbol = symbolChar;
             boolean found = false;
             for (String row : shape) {
                 if (row.indexOf(symbol) != -1) {
@@ -78,12 +79,23 @@ public final class Recipes {
                 }
             }
             if (found) {
-                recipe.setIngredient(symbol, (Material) ingredients[i + 1]);
+                recipe.setIngredient(symbol, material);
             }
         }
         return recipe;
     }
     private static NamespacedKey createNamespacedKey(String key) {
         return new NamespacedKey(plugin, key);
+    }
+
+    public static Material getBaseMaterial(Material tool) {
+        return switch (tool) {
+            case WOODEN_SWORD -> Material.OAK_PLANKS;
+            case STONE_SWORD -> Material.COBBLESTONE;
+            case GOLDEN_SWORD -> Material.GOLD_INGOT;
+            case IRON_SWORD -> Material.IRON_INGOT;
+            case DIAMOND_SWORD -> Material.DIAMOND;
+            default -> Material.EMERALD;
+        };
     }
 }


### PR DESCRIPTION
This PR refactors several systems to improve:
- maintainability,
- consistency,
- runtime safety

across combat logic, custom items, and recipe registration.

### Changes

- Introduces a centralized `CustomModelDataIds` registry to replace scattered magic numbers used for all the items.
- Simplifies and deduplicates recipe implementations by moving shared material lookup logic into `Recipes#getBaseMaterial`.
- Cleans up combat/event handling with safer null checks, reusable helpers, and more reliable floating-point comparisons.
- Fixes multiple edge cases and logic issues:
  - corrected cooldown time calculations
  - fixed shield/attack cooldown equality checks
  - prevented potential world null access in particles/sounds
  - improved smithing result naming safety
  - stabilized hash-based model data generation

- Refactors redstone-powered bow/crossbow handling into reusable helper methods for clearer behavior and less duplicated code.
- Improves recipe validation and config migration safety with stronger type checks.
- Rebalances the `op_sword` recipe damage value to a sane limit.

### Motivation

The previous implementation relied heavily on duplicated logic and hardcoded model data values spread throughout the codebase, making future maintenance error-prone and difficult to extend. This refactor reduces the likelihood of subtle gameplay bugs while preserving existing functionality and config compatibility.